### PR TITLE
Add back button support to profile screen

### DIFF
--- a/lib/presentation/profile_screen/profile_screen.dart
+++ b/lib/presentation/profile_screen/profile_screen.dart
@@ -36,10 +36,7 @@ class ProfileScreenState extends ConsumerState<ProfileScreen> {
             ],
           ),
         ),
-        bottomNavigationBar: SizedBox(
-          width: double.maxFinite,
-          child: _buildBottomBar(context),
-        ),
+        bottomNavigationBar: const BottomNavigation(),
       ),
     );
   }
@@ -52,6 +49,8 @@ class ProfileScreenState extends ConsumerState<ProfileScreen> {
       titleColor: theme.textTheme.headlineSmall?.color,
       profileIcon: ImageConstant.imgIGray600,
       onProfileTap: () => _onTapSettings(context),
+      showBackButton: true,
+      onBackTap: () => Navigator.pop(context),
     );
   }
 
@@ -189,8 +188,18 @@ class ProfileScreenState extends ConsumerState<ProfileScreen> {
     );
   }
 
-  /// Section Widget - Bottom Navigation Bar
-  Widget _buildBottomBar(BuildContext context) {
+  /// Settings button tap
+  void _onTapSettings(BuildContext context) {
+    NavigatorService.pushNamed(AppRoutes.editProfileScreen);
+  }
+}
+
+/// Bottom navigation menu displayed in the Profile screen
+class BottomNavigation extends StatelessWidget {
+  const BottomNavigation({super.key});
+
+  @override
+  Widget build(BuildContext context) {
     List<CustomBottomBarItem> bottomBarItemList = [
       CustomBottomBarItem(
         iconPath: ImageConstant.imgNavChat,
@@ -219,10 +228,5 @@ class ProfileScreenState extends ConsumerState<ProfileScreen> {
       padding: EdgeInsets.symmetric(horizontal: 70.h, vertical: 14.h),
       height: 84.h,
     );
-  }
-
-  /// Settings button tap
-  void _onTapSettings(BuildContext context) {
-    NavigatorService.pushNamed(AppRoutes.editProfileScreen);
   }
 }

--- a/lib/widgets/custom_app_bar.dart
+++ b/lib/widgets/custom_app_bar.dart
@@ -22,7 +22,7 @@ import './custom_image_view.dart';
  * @param height - Height of the app bar
  */
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
-  CustomAppBar({
+ CustomAppBar({
     Key? key,
     this.backgroundColor,
     this.logoImage,
@@ -31,6 +31,8 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.profileIcon,
     this.onProfileTap,
     this.height,
+    this.showBackButton = false,
+    this.onBackTap,
   }) : super(key: key);
 
   /// Background color of the app bar
@@ -54,6 +56,12 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// Height of the app bar
   final double? height;
 
+  /// Whether to display a back button on the leading side
+  final bool showBackButton;
+
+  /// Callback when the back button is tapped
+  final VoidCallback? onBackTap;
+
   @override
   Size get preferredSize => Size.fromHeight(height ?? 84.h);
 
@@ -64,6 +72,12 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       elevation: 0,
       automaticallyImplyLeading: false,
       toolbarHeight: height ?? 84.h,
+      leading: showBackButton
+          ? IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: onBackTap,
+            )
+          : null,
       title: Row(
         children: [
           if (logoImage != null) ...[


### PR DESCRIPTION
## Summary
- allow `CustomAppBar` to display an optional back button
- show the back button on the profile screen and wire its behavior
- use `BottomNavigation` widget as the profile screen's bottom menu

## Testing
- `dart format lib/widgets/custom_app_bar.dart lib/presentation/profile_screen/profile_screen.dart` *(command failed: command not found)*
- `flutter analyze` *(command failed: command not found)*
- `flutter test` *(command failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c5acb0308323b4cbe509df5d1bba